### PR TITLE
Add web viewer for transaction log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ Thumbs.db
 
 # Logs (local transaction log is in ~/.arweave-markdown/)
 *.log
+
+# Viewer's generated files (created by npm run viewer)
+plugins/markdown-provenance/viewer/transactions.jsonl
+plugins/markdown-provenance/viewer/index-loaded.html

--- a/README.md
+++ b/README.md
@@ -235,6 +235,38 @@ Or get a count:
 wc -l ~/.markdown-provenance/transactions.jsonl
 ```
 
+## Web Viewer
+
+A visual interface for viewing your upload history is available at `plugins/markdown-provenance/viewer/index.html`.
+
+### Features
+
+- **Load transactions.jsonl** via file picker or drag-and-drop
+- **View all uploads** in a sortable table with:
+  - Timestamp
+  - Filename
+  - File size
+  - Transaction ID
+  - IPFS CID
+- **Quick links** to ViewBlock explorer and direct Arweave URLs
+- **Fetch tags** from Arweave GraphQL to see Author, Source, and other metadata
+- **Statistics** showing total uploads, total size, and latest upload date
+
+### Usage
+
+Open the viewer in your browser:
+
+```bash
+# Using the default browser
+open plugins/markdown-provenance/viewer/index.html
+
+# Or with a specific browser
+google-chrome plugins/markdown-provenance/viewer/index.html
+firefox plugins/markdown-provenance/viewer/index.html
+```
+
+Then load your `~/.markdown-provenance/transactions.jsonl` file using the file picker or by dragging and dropping it onto the page.
+
 ## How It Works
 
 1. **File Reading**: The script reads your markdown file

--- a/README.md
+++ b/README.md
@@ -237,35 +237,30 @@ wc -l ~/.markdown-provenance/transactions.jsonl
 
 ## Web Viewer
 
-A visual interface for viewing your upload history is available at `plugins/markdown-provenance/viewer/index.html`.
+A visual interface for viewing your upload history.
 
 ### Features
 
-- **Load transactions.jsonl** via file picker or drag-and-drop
-- **View all uploads** in a sortable table with:
-  - Timestamp
-  - Filename
-  - File size
-  - Transaction ID
-  - IPFS CID
+- **Auto-load transactions** when opened via `npm run viewer`
+- **View all uploads** in a sortable table with timestamp, filename, size, transaction ID, and IPFS CID
 - **Quick links** to ViewBlock explorer and direct Arweave URLs
 - **Fetch tags** from Arweave GraphQL to see Author, Source, and other metadata
 - **Statistics** showing total uploads, total size, and latest upload date
 
 ### Usage
 
-Open the viewer in your browser:
-
 ```bash
-# Using the default browser
-open plugins/markdown-provenance/viewer/index.html
-
-# Or with a specific browser
-google-chrome plugins/markdown-provenance/viewer/index.html
-firefox plugins/markdown-provenance/viewer/index.html
+cd plugins/markdown-provenance
+npm run viewer
 ```
 
-Then load your `~/.markdown-provenance/transactions.jsonl` file using the file picker or by dragging and dropping it onto the page.
+This automatically loads your `~/.markdown-provenance/transactions.jsonl` and opens the viewer in your browser.
+
+You can also open the viewer manually and load the file via drag-and-drop:
+
+```bash
+open plugins/markdown-provenance/viewer/index.html
+```
 
 ## How It Works
 

--- a/plugins/markdown-provenance/package.json
+++ b/plugins/markdown-provenance/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "upload": "npx tsx scripts/upload-to-arweave.ts",
-    "generate-wallet": "npx tsx scripts/generate-wallet.ts"
+    "generate-wallet": "npx tsx scripts/generate-wallet.ts",
+    "viewer": "node scripts/open-viewer.js"
   },
   "dependencies": {
     "@ardrive/turbo-sdk": "^1.0.0",

--- a/plugins/markdown-provenance/scripts/open-viewer.js
+++ b/plugins/markdown-provenance/scripts/open-viewer.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const viewerDir = join(__dirname, '..', 'viewer');
+
+// Read the base HTML
+const html = readFileSync(join(viewerDir, 'index.html'), 'utf8');
+
+// Try to read transactions
+let transactions = '';
+try {
+  transactions = readFileSync(join(homedir(), '.markdown-provenance', 'transactions.jsonl'), 'utf8');
+} catch (e) {
+  console.log('No transactions.jsonl found - viewer will open empty');
+}
+
+// Escape for embedding in template literal
+const escaped = transactions.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
+
+// Inject the data
+const output = html.replace('</head>', `<script>var EMBEDDED_TRANSACTIONS = \`${escaped}\`;</script></head>`);
+
+// Write the loaded version
+const outputPath = join(viewerDir, 'index-loaded.html');
+writeFileSync(outputPath, output);
+
+// Open it
+execSync(`open "${outputPath}"`);
+console.log('Viewer opened with', transactions.split('\n').filter(Boolean).length, 'transactions');

--- a/plugins/markdown-provenance/viewer/index.html
+++ b/plugins/markdown-provenance/viewer/index.html
@@ -1,0 +1,700 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Markdown Provenance Viewer</title>
+  <style>
+    :root {
+      --bg-primary: #1a1a2e;
+      --bg-secondary: #16213e;
+      --bg-card: #0f3460;
+      --text-primary: #eaeaea;
+      --text-secondary: #a0a0a0;
+      --accent: #e94560;
+      --accent-hover: #ff6b6b;
+      --link: #4ecdc4;
+      --link-hover: #45b7aa;
+      --border: #2a2a4a;
+      --success: #4ade80;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      min-height: 100vh;
+      line-height: 1.6;
+    }
+
+    .container {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 2rem;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 2rem;
+      padding-bottom: 1.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    h1 {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+      background: linear-gradient(135deg, var(--accent), var(--link));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .subtitle {
+      color: var(--text-secondary);
+      font-size: 1rem;
+    }
+
+    .upload-section {
+      background: var(--bg-secondary);
+      border-radius: 12px;
+      padding: 2rem;
+      margin-bottom: 2rem;
+      text-align: center;
+      border: 2px dashed var(--border);
+      transition: border-color 0.3s ease;
+    }
+
+    .upload-section:hover {
+      border-color: var(--accent);
+    }
+
+    .upload-section.dragover {
+      border-color: var(--accent);
+      background: var(--bg-card);
+    }
+
+    .file-input-wrapper {
+      position: relative;
+      display: inline-block;
+    }
+
+    .file-input {
+      position: absolute;
+      left: 0;
+      top: 0;
+      opacity: 0;
+      width: 100%;
+      height: 100%;
+      cursor: pointer;
+    }
+
+    .upload-btn {
+      display: inline-block;
+      padding: 0.75rem 1.5rem;
+      background: var(--accent);
+      color: white;
+      border-radius: 8px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.3s ease;
+    }
+
+    .upload-btn:hover {
+      background: var(--accent-hover);
+    }
+
+    .upload-hint {
+      margin-top: 1rem;
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+    }
+
+    .upload-hint code {
+      background: var(--bg-card);
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+    }
+
+    .stats {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 2rem;
+      flex-wrap: wrap;
+    }
+
+    .stat-card {
+      background: var(--bg-secondary);
+      border-radius: 8px;
+      padding: 1rem 1.5rem;
+      flex: 1;
+      min-width: 150px;
+    }
+
+    .stat-value {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--accent);
+    }
+
+    .stat-label {
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+    }
+
+    .table-container {
+      background: var(--bg-secondary);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+
+    .table-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 1.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .table-title {
+      font-size: 1.125rem;
+      font-weight: 600;
+    }
+
+    .fetch-tags-btn {
+      padding: 0.5rem 1rem;
+      background: var(--bg-card);
+      color: var(--text-primary);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.875rem;
+      transition: all 0.3s ease;
+    }
+
+    .fetch-tags-btn:hover:not(:disabled) {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+
+    .fetch-tags-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      text-align: left;
+      padding: 1rem 1.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    th {
+      background: var(--bg-card);
+      color: var(--text-secondary);
+      font-weight: 600;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      user-select: none;
+      white-space: nowrap;
+    }
+
+    th:hover {
+      color: var(--text-primary);
+    }
+
+    th .sort-icon {
+      margin-left: 0.5rem;
+      opacity: 0.5;
+    }
+
+    th.sorted .sort-icon {
+      opacity: 1;
+      color: var(--accent);
+    }
+
+    tr:hover td {
+      background: var(--bg-card);
+    }
+
+    .mono {
+      font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+      font-size: 0.875rem;
+    }
+
+    .truncate {
+      max-width: 150px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    a {
+      color: var(--link);
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+
+    a:hover {
+      color: var(--link-hover);
+      text-decoration: underline;
+    }
+
+    .links {
+      display: flex;
+      gap: 0.75rem;
+    }
+
+    .link-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.25rem 0.5rem;
+      background: var(--bg-card);
+      border-radius: 4px;
+      font-size: 0.75rem;
+      white-space: nowrap;
+    }
+
+    .link-btn:hover {
+      background: var(--accent);
+      color: white;
+      text-decoration: none;
+    }
+
+    .tags-cell {
+      max-width: 250px;
+    }
+
+    .tag {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      background: var(--bg-card);
+      border-radius: 4px;
+      font-size: 0.75rem;
+      margin: 0.125rem;
+      white-space: nowrap;
+    }
+
+    .tag-name {
+      color: var(--text-secondary);
+    }
+
+    .tag-value {
+      color: var(--text-primary);
+    }
+
+    .size {
+      white-space: nowrap;
+    }
+
+    .timestamp {
+      white-space: nowrap;
+      color: var(--text-secondary);
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 4rem 2rem;
+      color: var(--text-secondary);
+    }
+
+    .empty-state svg {
+      width: 64px;
+      height: 64px;
+      margin-bottom: 1rem;
+      opacity: 0.5;
+    }
+
+    .loading {
+      display: inline-block;
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+      margin-left: 0.5rem;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .hidden {
+      display: none;
+    }
+
+    @media (max-width: 768px) {
+      .container {
+        padding: 1rem;
+      }
+
+      th, td {
+        padding: 0.75rem;
+        font-size: 0.875rem;
+      }
+
+      .truncate {
+        max-width: 100px;
+      }
+
+      .links {
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+    }
+
+    .responsive-table {
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Markdown Provenance Viewer</h1>
+      <p class="subtitle">View your permanent Arweave uploads</p>
+    </header>
+
+    <section class="upload-section" id="dropZone">
+      <div class="file-input-wrapper">
+        <span class="upload-btn">Choose transactions.jsonl</span>
+        <input type="file" class="file-input" id="fileInput" accept=".jsonl,.json">
+      </div>
+      <p class="upload-hint">
+        or drag and drop your file here<br>
+        <code>~/.markdown-provenance/transactions.jsonl</code>
+      </p>
+    </section>
+
+    <section class="stats hidden" id="stats">
+      <div class="stat-card">
+        <div class="stat-value" id="totalUploads">0</div>
+        <div class="stat-label">Total Uploads</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value" id="totalSize">0 KB</div>
+        <div class="stat-label">Total Size</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value" id="latestUpload">-</div>
+        <div class="stat-label">Latest Upload</div>
+      </div>
+    </section>
+
+    <section class="table-container hidden" id="tableSection">
+      <div class="table-header">
+        <h2 class="table-title">Transaction History</h2>
+        <button class="fetch-tags-btn" id="fetchTagsBtn">
+          Fetch Tags from Arweave
+        </button>
+      </div>
+      <div class="responsive-table">
+        <table>
+          <thead>
+            <tr>
+              <th data-sort="timestamp" class="sorted">
+                Timestamp <span class="sort-icon">▼</span>
+              </th>
+              <th data-sort="file">
+                Filename <span class="sort-icon">▼</span>
+              </th>
+              <th data-sort="size">
+                Size <span class="sort-icon">▼</span>
+              </th>
+              <th data-sort="txId">
+                Transaction ID <span class="sort-icon">▼</span>
+              </th>
+              <th data-sort="cid">
+                IPFS CID <span class="sort-icon">▼</span>
+              </th>
+              <th>Links</th>
+              <th>Tags</th>
+            </tr>
+          </thead>
+          <tbody id="tableBody">
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="empty-state" id="emptyState">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
+      <p>Load your transactions.jsonl file to view uploads</p>
+    </section>
+  </div>
+
+  <script>
+    // State
+    let transactions = [];
+    let sortColumn = 'timestamp';
+    let sortDirection = 'desc';
+    let tagCache = new Map();
+
+    // DOM elements
+    const fileInput = document.getElementById('fileInput');
+    const dropZone = document.getElementById('dropZone');
+    const stats = document.getElementById('stats');
+    const tableSection = document.getElementById('tableSection');
+    const tableBody = document.getElementById('tableBody');
+    const emptyState = document.getElementById('emptyState');
+    const fetchTagsBtn = document.getElementById('fetchTagsBtn');
+
+    // File handling
+    fileInput.addEventListener('change', (e) => {
+      if (e.target.files[0]) {
+        loadFile(e.target.files[0]);
+      }
+    });
+
+    dropZone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      dropZone.classList.add('dragover');
+    });
+
+    dropZone.addEventListener('dragleave', () => {
+      dropZone.classList.remove('dragover');
+    });
+
+    dropZone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      dropZone.classList.remove('dragover');
+      if (e.dataTransfer.files[0]) {
+        loadFile(e.dataTransfer.files[0]);
+      }
+    });
+
+    function loadFile(file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const content = e.target.result;
+        parseTransactions(content);
+      };
+      reader.readAsText(file);
+    }
+
+    function parseTransactions(content) {
+      const lines = content.trim().split('\n').filter(line => line.trim());
+      transactions = lines.map(line => {
+        try {
+          return JSON.parse(line);
+        } catch (e) {
+          console.error('Failed to parse line:', line);
+          return null;
+        }
+      }).filter(Boolean);
+
+      if (transactions.length > 0) {
+        updateStats();
+        renderTable();
+        stats.classList.remove('hidden');
+        tableSection.classList.remove('hidden');
+        emptyState.classList.add('hidden');
+      }
+    }
+
+    function updateStats() {
+      const totalUploads = transactions.length;
+      const totalSize = transactions.reduce((sum, t) => sum + (t.size || 0), 0);
+      const latest = transactions.reduce((latest, t) => {
+        const date = new Date(t.timestamp);
+        return date > latest ? date : latest;
+      }, new Date(0));
+
+      document.getElementById('totalUploads').textContent = totalUploads;
+      document.getElementById('totalSize').textContent = formatSize(totalSize);
+      document.getElementById('latestUpload').textContent = formatRelativeTime(latest);
+    }
+
+    function formatSize(bytes) {
+      if (bytes === 0) return '0 B';
+      const k = 1024;
+      const sizes = ['B', 'KB', 'MB', 'GB'];
+      const i = Math.floor(Math.log(bytes) / Math.log(k));
+      return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    }
+
+    function formatRelativeTime(date) {
+      const now = new Date();
+      const diff = now - date;
+      const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+      if (days === 0) return 'Today';
+      if (days === 1) return 'Yesterday';
+      if (days < 7) return `${days} days ago`;
+      if (days < 30) return `${Math.floor(days / 7)} weeks ago`;
+      return `${Math.floor(days / 30)} months ago`;
+    }
+
+    function formatTimestamp(timestamp) {
+      const date = new Date(timestamp);
+      return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    }
+
+    function truncate(str, maxLen = 12) {
+      if (!str) return '-';
+      if (str.length <= maxLen) return str;
+      return str.slice(0, maxLen) + '...';
+    }
+
+    function sortTransactions() {
+      return [...transactions].sort((a, b) => {
+        let aVal = a[sortColumn];
+        let bVal = b[sortColumn];
+
+        if (sortColumn === 'timestamp') {
+          aVal = new Date(aVal);
+          bVal = new Date(bVal);
+        } else if (sortColumn === 'size') {
+          aVal = aVal || 0;
+          bVal = bVal || 0;
+        } else {
+          aVal = (aVal || '').toString().toLowerCase();
+          bVal = (bVal || '').toString().toLowerCase();
+        }
+
+        if (aVal < bVal) return sortDirection === 'asc' ? -1 : 1;
+        if (aVal > bVal) return sortDirection === 'asc' ? 1 : -1;
+        return 0;
+      });
+    }
+
+    function renderTable() {
+      const sorted = sortTransactions();
+
+      tableBody.innerHTML = sorted.map(t => {
+        const tags = tagCache.get(t.txId);
+        const tagsHtml = tags ? renderTags(tags) : '<span class="tag"><span class="tag-value">-</span></span>';
+
+        return `
+          <tr>
+            <td class="timestamp">${formatTimestamp(t.timestamp)}</td>
+            <td class="mono">${escapeHtml(t.file)}</td>
+            <td class="size">${formatSize(t.size || 0)}</td>
+            <td class="mono truncate" title="${escapeHtml(t.txId)}">${truncate(t.txId, 12)}</td>
+            <td class="mono truncate" title="${escapeHtml(t.cid)}">${truncate(t.cid, 16)}</td>
+            <td class="links">
+              <a href="https://viewblock.io/arweave/tx/${encodeURIComponent(t.txId)}" target="_blank" class="link-btn">ViewBlock</a>
+              <a href="https://arweave.net/${encodeURIComponent(t.txId)}" target="_blank" class="link-btn">Arweave</a>
+            </td>
+            <td class="tags-cell">${tagsHtml}</td>
+          </tr>
+        `;
+      }).join('');
+
+      // Update sort indicators
+      document.querySelectorAll('th[data-sort]').forEach(th => {
+        th.classList.toggle('sorted', th.dataset.sort === sortColumn);
+        const icon = th.querySelector('.sort-icon');
+        if (th.dataset.sort === sortColumn) {
+          icon.textContent = sortDirection === 'asc' ? '▲' : '▼';
+        } else {
+          icon.textContent = '▼';
+        }
+      });
+    }
+
+    function renderTags(tags) {
+      const importantTags = ['Author', 'File-Name', 'Source', 'Type'];
+      const filtered = tags.filter(t => importantTags.includes(t.name));
+
+      if (filtered.length === 0) {
+        return '<span class="tag"><span class="tag-value">-</span></span>';
+      }
+
+      return filtered.map(t =>
+        `<span class="tag"><span class="tag-name">${escapeHtml(t.name)}:</span> <span class="tag-value">${escapeHtml(truncate(t.value, 20))}</span></span>`
+      ).join('');
+    }
+
+    function escapeHtml(str) {
+      if (!str) return '';
+      const div = document.createElement('div');
+      div.textContent = str;
+      return div.innerHTML;
+    }
+
+    // Sorting
+    document.querySelectorAll('th[data-sort]').forEach(th => {
+      th.addEventListener('click', () => {
+        const column = th.dataset.sort;
+        if (sortColumn === column) {
+          sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+          sortColumn = column;
+          sortDirection = 'desc';
+        }
+        renderTable();
+      });
+    });
+
+    // Fetch tags from Arweave
+    fetchTagsBtn.addEventListener('click', async () => {
+      if (transactions.length === 0) return;
+
+      fetchTagsBtn.disabled = true;
+      fetchTagsBtn.innerHTML = 'Fetching... <span class="loading"></span>';
+
+      const GRAPHQL_ENDPOINT = 'https://arweave.net/graphql';
+
+      for (const t of transactions) {
+        if (tagCache.has(t.txId)) continue;
+
+        try {
+          const query = `
+            query {
+              transaction(id: "${t.txId}") {
+                tags {
+                  name
+                  value
+                }
+              }
+            }
+          `;
+
+          const response = await fetch(GRAPHQL_ENDPOINT, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query })
+          });
+
+          const data = await response.json();
+          if (data.data?.transaction?.tags) {
+            tagCache.set(t.txId, data.data.transaction.tags);
+          }
+        } catch (e) {
+          console.error(`Failed to fetch tags for ${t.txId}:`, e);
+        }
+
+        // Small delay to avoid rate limiting
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+
+      fetchTagsBtn.disabled = false;
+      fetchTagsBtn.innerHTML = 'Fetch Tags from Arweave';
+      renderTable();
+    });
+  </script>
+</body>
+</html>

--- a/plugins/markdown-provenance/viewer/index.html
+++ b/plugins/markdown-provenance/viewer/index.html
@@ -649,6 +649,11 @@
       });
     });
 
+    // Auto-load embedded data if present (injected by npm run viewer)
+    if (typeof EMBEDDED_TRANSACTIONS !== 'undefined' && EMBEDDED_TRANSACTIONS) {
+      parseTransactions(EMBEDDED_TRANSACTIONS);
+    }
+
     // Fetch tags from Arweave
     fetchTagsBtn.addEventListener('click', async () => {
       if (transactions.length === 0) return;


### PR DESCRIPTION
## Summary
- Add standalone HTML/CSS/JS web viewer for browsing transaction history
- Support loading transactions.jsonl via file picker or drag-and-drop
- Display uploads in sortable table with clickable Arweave links
- Fetch transaction tags from Arweave GraphQL API

## Test plan
- [x] Open viewer/index.html in browser
- [x] Load ~/.markdown-provenance/transactions.jsonl
- [x] Verify table displays all columns correctly
- [x] Click ViewBlock/Arweave links and verify they work
- [x] Click "Fetch Tags from Arweave" and verify tags populate